### PR TITLE
hotfix: fix gitlab-job image

### DIFF
--- a/docker-build/run.sh
+++ b/docker-build/run.sh
@@ -1,6 +1,9 @@
 #!/bin/bash -eu
 
 IMAGES="${IMAGES:-}"
+DRY_RUN="${DRY_RUN:-}"
+CACHE="${CACHE:-}"
+NO_PULL="${NO_PULL:-}"
 
 if [[ -z $IMAGES ]] ; then
     IMAGES=$(git diff --name-only "$GIT_DIFF" | \

--- a/docker-push/run.sh
+++ b/docker-push/run.sh
@@ -1,6 +1,9 @@
 #!/bin/bash -eu
 
+DRY_RUN="${DRY_RUN:-}"
 IMAGES="${IMAGES:-}"
+CI_REGISTRY="${CI_REGISTRY:-}"
+
 if [[ -z $IMAGES ]] ; then
     IMAGES=$(git diff --name-only "$GIT_DIFF" | \
         sort -u | \

--- a/docker-push/run.sh
+++ b/docker-push/run.sh
@@ -1,8 +1,7 @@
 #!/bin/bash -eu
 
-DRY_RUN="${DRY_RUN:-}"
 IMAGES="${IMAGES:-}"
-CI_REGISTRY="${CI_REGISTRY:-}"
+DRY_RUN="${DRY_RUN:-}"
 
 if [[ -z $IMAGES ]] ; then
     IMAGES=$(git diff --name-only "$GIT_DIFF" | \

--- a/docker-push/tests/push.bats
+++ b/docker-push/tests/push.bats
@@ -6,3 +6,10 @@
     [[ $status -eq 0 ]]
     [[ $output == "gitlab-job" ]]
 }
+@test "make dry run" {
+    cd ..
+    run make push -e IMAGES=gitlab-job -e CURRENT_BRANCH=push-test "avenga/docker-push:$VERSION"
+    echo "$output"
+    [[ $status -eq 2 ]]
+    [[ $output =~ "Skipping since not on ONLY_BRANCH master" ]]
+}

--- a/docker-test/Dockerfile
+++ b/docker-test/Dockerfile
@@ -3,7 +3,7 @@ FROM avenga/docker AS release
 # Install bats-core and other requirements
 COPY --from=bats/bats:latest /opt/bats /opt/bats
 RUN ln -s /opt/bats/bin/bats /usr/sbin/bats \
-    && apk --quiet --no-progress --no-cache add docker-compose curl jq
+    && apk --quiet --no-progress --no-cache add docker-compose curl jq make
 #
 # DEFAULTS
 #

--- a/docker-test/tests/docker.bats
+++ b/docker-test/tests/docker.bats
@@ -1,5 +1,5 @@
 @test "docker-compose version" {
-    run docker run --rm "avenga/docker-test:$VERSION" -c 'docker-compose --version'
+    run docker run --rm "avenga/docker-test:$VERSION" docker-compose --version
     echo "$output"
     [[ $status -eq 0 ]]
     [[ $output =~ docker-compose\ version\ 1 ]]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,4 +3,4 @@ ENV WORKDIR=/work
 WORKDIR ${WORKDIR}
 VOLUME ${WORKDIR}
 RUN apk --quiet --no-progress --no-cache add bash
-ENTRYPOINT ["bash"]
+CMD ["bash"]

--- a/docker/tests/docker.bats
+++ b/docker/tests/docker.bats
@@ -1,12 +1,18 @@
 @test "-c env" {
-    run docker run --rm "avenga/docker:$VERSION" -c env
+    run docker run --rm "avenga/docker:$VERSION" env
     echo "$output"
     [[ $status -eq 0 ]]
     [[ $output =~ "WORKDIR=/work" ]]
 }
 @test "docker version" {
-    run docker run --rm "avenga/docker:$VERSION" -c 'docker --version'
+    run docker run --rm "avenga/docker:$VERSION" docker --version
     echo "$output"
     [[ $status -eq 0 ]]
     [[ $output =~ version\ 19 ]]
+}
+# Prevent DEVOPS-298
+@test "sh shell works" {
+    run docker run --rm "avenga/docker:$VERSION" /bin/sh -c env
+    echo "$output"
+    [[ $status -eq 0 ]]
 }

--- a/gitlab-job/tests/version.bats
+++ b/gitlab-job/tests/version.bats
@@ -1,27 +1,39 @@
 @test "docker-compose version" {
-    run docker run --rm "avenga/gitlab-job:$VERSION" -c 'docker-compose --version'
+    run docker run --rm "avenga/gitlab-job:$VERSION" docker-compose --version
     echo "$output"
     [[ $status -eq 0 ]]
     [[ $output =~ "docker-compose version 1" ]]
 }
 
 @test "jq version" {
-    run docker run --rm "avenga/gitlab-job:$VERSION" -c 'jq --version'
+    run docker run --rm "avenga/gitlab-job:$VERSION" jq --version
     echo "$output"
     [[ $status -eq 0 ]]
     [[ $output =~ "jq-master" ]]
 }
 
 @test "make version" {
-    run docker run --rm "avenga/gitlab-job:$VERSION" -c 'make --version'
+    run docker run --rm "avenga/gitlab-job:$VERSION" make --version
     echo "$output"
     [[ $status -eq 0 ]]
     [[ $output =~ "GNU Make 4" ]]
 }
 
 @test "bash version" {
-    run docker run --rm "avenga/gitlab-job:$VERSION" -c 'bash --version'
+    run docker run --rm "avenga/gitlab-job:$VERSION" bash --version
     echo "$output"
     [[ $status -eq 0 ]]
     [[ $output =~ "GNU bash, version 5" ]]
+}
+# Prevent DEVOPS-298
+@test "sh shell works" {
+    run docker run --rm "avenga/docker:$VERSION" /bin/sh -c env
+    echo "$output"
+    [[ $status -eq 0 ]]
+}
+# Prevent DEVOPS-298
+@test "bash shell works" {
+    run docker run --rm "avenga/docker:$VERSION" /bin/bash -c env
+    echo "$output"
+    [[ $status -eq 0 ]]
 }


### PR DESCRIPTION
This commit fixes a bug where gitlab-job couldn't run a shell via
`/bin/sh` or `/bin/bash`. This was because the image had an ENDPOINT
defined as `bash`. S. DEVOPS-298
Also bugs were found in `docker-build/run.sh` where undefined variables
were used and the script failed because of `set -u`.

docker-build/run.sh:
* defines all variables which might be unset

docker-test/tests/docker.bats:
* remove `-c` which was only necessary with ENDPOINT bash

docker/Dockerfile:
* change ENDPOINT bash to CMD bash. gitlab-job is build from this image.

docker/tests/docker.bats:
* removes `-c` which was only necessary with ENDPOINT bash
* adds test to validate that `/bin/sh` is working as cmd from
  commandline

gitlab-job/tests/version.bats:
* removes `-c` which was only necessary with ENDPOINT bash
* adds test to validate that `/bin/sh` and `/bin/bash` is working as cmd from
  commandline