### PR TITLE
Fixes missing var in docker-push entrypoint

### DIFF
--- a/docker-compose.ops.yml
+++ b/docker-compose.ops.yml
@@ -35,6 +35,7 @@ services:
       - DRY_RUN
       - CI_REGISTRY_PASSWORD
       - CI_REGISTRY_USER
+      - CI_REGISTRY
       - IMAGES
     volumes:
       - .:/work


### PR DESCRIPTION
This commit fixes a bug where the entrypoint `run.sh` from docker-push
failed because of the undefined variable CI_REGISTRY. The value is set
in `Makefile` but wasn't handed over to the container by docker-compose.