### PR TITLE
wordpress: use wordpress base image 5.9-php8.1-apache

### DIFF
--- a/wordpress/Dockerfile
+++ b/wordpress/Dockerfile
@@ -1,4 +1,4 @@
-ARG WORDPRESS_IMAGE_TAG=5.5.1-php7.4-apache
+ARG WORDPRESS_IMAGE_TAG=5.9-php8.1-apache
 FROM wordpress:${WORDPRESS_IMAGE_TAG} AS release
 
 # Add sudo in order to run wp-cli as the www-data user


### PR DESCRIPTION
Use latest Wordpress base image using PHP 8.1 on Apache.

Build with

```bash
VERSION=5.9-php8.1-apache make build -e IMAGES="wordpress"
```